### PR TITLE
Add links for switching between signup and signin forms

### DIFF
--- a/src/components/SignInForm.jsx
+++ b/src/components/SignInForm.jsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Label } from "../components/ui/label";
 import { Input } from "../components/ui/input";
 import { signIn } from "next-auth/react";
+import Link from "next/link"
 
 export function SignInForm() {
   const router = useRouter();
@@ -48,7 +49,16 @@ export function SignInForm() {
       <p className="text-neutral-600 text-sm max-w-sm mt-2 dark:text-neutral-300">
         Sign in to your account to continue using the app.
       </p>
-
+      <div className=" mt-4 flex flex-row gap-2  ">
+            <p>
+           Don't have an account?  
+            </p>
+            <button className="cursor-pointer  text-blue-500"  >
+              <Link href={'/signup'}>
+              sign up
+              </Link>
+              </button>
+          </div>
       <form className="my-8" onSubmit={handleSubmit}>
         <div className="flex flex-col space-y-4 mb-4">
           <Label htmlFor="email">Email Address</Label>
@@ -81,6 +91,7 @@ export function SignInForm() {
         >
           {loading ? "Signing in..." : "Sign in"}
         </button>
+         
       </form>
     </div>
   );

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Label } from "../components/ui/label";
 import { Input } from "../components/ui/input";
 import { Dropdown } from "./ui/Dropdown";
+import Link from "next/link"
 
 export function SignupForm() {
   const router = useRouter();
@@ -68,6 +69,16 @@ export function SignupForm() {
       <p className="text-neutral-600 text-sm max-w-sm mt-2 dark:text-neutral-300">
         Sign up for an account to start using the app.
       </p>
+      <div className=" mt-4 flex flex-row gap-2  ">
+            <p>
+           Already have an account?  
+            </p>
+            <button className="cursor-pointer  text-blue-500"  >
+              <Link href={'/signin'}>
+              sign in
+              </Link>
+              </button>
+       </div>
 
       <form className="my-8" onSubmit={handleSubmit}>
         <div className="flex flex-col space-y-4 mb-4">


### PR DESCRIPTION
Closes #4 

Description:
This PR implements the feature to add navigational links in both the signup and signin forms. Key changes include:

A "Don't have an account?" link in the signin form, which redirects users to the signup page.
An "Already have an account?" link in the signup form, which redirects users to the signin page.